### PR TITLE
Fix billboarding

### DIFF
--- a/.changeset/good-buckets-swim.md
+++ b/.changeset/good-buckets-swim.md
@@ -1,0 +1,5 @@
+---
+"vfx": patch
+---
+
+**Fixed:** billboarding code in vertex shader was borked.

--- a/packages/vfx/src/shader.ts
+++ b/packages/vfx/src/shader.ts
@@ -52,6 +52,11 @@ void setVaryings() {
 void main() {
   setVaryings();
 
+  /* Apply Billboarding */
+  if (u_billboard) {
+    csm_Position = billboard(csm_Position.xy, viewMatrix);
+  }
+
   /* Start with an origin offset */
   vec3 offset = vec3(0.0, 0.0, 0.0);
 
@@ -66,11 +71,6 @@ void main() {
 
   /* Apply the offset */
   csm_Position += offset;
-
-  /* Apply Billboarding */
-  if (u_billboard) {
-    csm_Position = billboard(csm_Position.xy, viewMatrix);
-  }
 }
 
 `


### PR DESCRIPTION
The billboarding conversion was stupidly running _after_ the animation code. It should run _before_ it.